### PR TITLE
RNRBC-120: Ignore nbsp when verifying content

### DIFF
--- a/test/uk/gov/hmrc/residencenilratebandcalculator/views/HtmlSpec.scala
+++ b/test/uk/gov/hmrc/residencenilratebandcalculator/views/HtmlSpec.scala
@@ -52,7 +52,7 @@ trait HtmlSpec extends UnitSpec with WithFakeApplication { self: UnitSpec =>
   def assertPageTitleEqualsMessage(doc: Document, expectedMessageKey: String, args: Any*) = {
     val headers = doc.getElementsByTag("h1")
     headers.size shouldBe 1
-    headers.first.text shouldBe messages(expectedMessageKey, args:_*)
+    headers.first.text.replaceAll("\u00a0", " ") shouldBe messages(expectedMessageKey, args:_*).replaceAll("&nbsp;", " ")
   }
 
   def assertContainsText(doc:Document, text: String) = assert(doc.toString.contains(text), "\n\ntext " + text + " was not rendered on the page.\n")


### PR DESCRIPTION
Ignore nbsp when verifying content