### PR TITLE
DL-7124 - Re-added .visually-hidden/replaced .govuk-visually-hidden

### DIFF
--- a/app/assets/stylesheets/rnrb.css
+++ b/app/assets/stylesheets/rnrb.css
@@ -1,0 +1,10 @@
+.visually-hidden {
+    position:absolute;
+    width: 1px;
+    height: 1px;
+    margin: 1px;
+    padding: 0;
+    overflow:hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/Layout.scala.html
@@ -54,6 +54,7 @@
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/rnrb-ie.css")" />
     <![endif]-->
     <link rel="stylesheet" media="print" href='@routes.Assets.versioned("stylesheets/rnrb-print.css")' />
+    <link rel="stylesheet" type="text/css" href ='@routes.Assets.versioned("stylesheets/rnrb.css")'>
 
     @if(timeoutEnabled) {
         @hmrcTimeoutDialogHelper(

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/assets_passing_to_direct_descendants.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/assets_passing_to_direct_descendants.scala.html
@@ -51,7 +51,7 @@
 
         @inputYesNo(
             label = HtmlContent(heading(messages("assets_passing_to_direct_descendants.title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
 

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/chargeable_estate_value.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/chargeable_estate_value.scala.html
@@ -43,7 +43,7 @@
 
         @inputValue(
             label = messages("chargeable_estate_value.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/chargeable_inherited_property_value.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/chargeable_inherited_property_value.scala.html
@@ -48,7 +48,7 @@
 
         @inputValue(
             label = messages("chargeable_inherited_property_value.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/chargeable_property_value.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/chargeable_property_value.scala.html
@@ -44,7 +44,7 @@
 
         @inputValue(
             label = messages("chargeable_property_value.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/claim_downsizing_threshold.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/claim_downsizing_threshold.scala.html
@@ -51,7 +51,7 @@
 
         @inputYesNo(
             label = HtmlContent(heading(messages("claim_downsizing_threshold.title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
 

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/date_of_death.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/date_of_death.scala.html
@@ -44,7 +44,7 @@
 
         @inputDateInline(
             content = messages("date_of_death.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             hintContent = Some(messages("date_of_death.example")),
             field = form("dateOfDeath"),
             pageHeading = false

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/date_property_was_changed.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/date_property_was_changed.scala.html
@@ -47,7 +47,7 @@
 
         @inputDateInline(
             content = messages("date_property_was_changed.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             hintContent = Some(messages("date_property_was_changed.hint")),
             field = form("dateOfDownsizing"),
             pageHeading = false

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/exemptions_and_relief_claimed.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/exemptions_and_relief_claimed.scala.html
@@ -51,7 +51,7 @@
         </ul>
         @inputYesNo(
             label = HtmlContent(heading(messages("exemptions_and_relief_claimed.browser_title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
 

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/grossing_up_on_estate_assets.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/grossing_up_on_estate_assets.scala.html
@@ -48,7 +48,7 @@
 
         @inputYesNo(
             label = HtmlContent(heading(messages("grossing_up_on_estate_assets.browser_title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
         @submitButton()

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/grossing_up_on_estate_property.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/grossing_up_on_estate_property.scala.html
@@ -45,7 +45,7 @@
 
         @inputYesNo(
             label = HtmlContent(heading(messages("grossing_up_on_estate_property.browser_title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
 

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/part_of_estate_passing_to_direct_descendants.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/part_of_estate_passing_to_direct_descendants.scala.html
@@ -67,7 +67,7 @@ implicit request: Request[_], messages: Messages)
 
         @inputYesNo(
             label = HtmlContent(heading(messages("part_of_estate_passing_to_direct_descendants.browser_title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
 

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/percentage_passed_to_direct_descendants.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/percentage_passed_to_direct_descendants.scala.html
@@ -44,7 +44,7 @@
 
         @inputValue(
             label = messages("percentage_passed_to_direct_descendants.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             shortAnswer = true,
             field = form("value"),
             suffix = Some(messages("sign.percentage"))

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/property_in_estate.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/property_in_estate.scala.html
@@ -46,7 +46,7 @@
 
         @inputYesNo(
             label = HtmlContent(heading(messages("property_in_estate.browser_title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
 

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/property_passing_to_direct_descendants.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/property_passing_to_direct_descendants.scala.html
@@ -48,7 +48,7 @@
 
         @inputRadio(
             legend = heading(messages("property_passing_to_direct_descendants.title")),
-            legendClass = Some("govuk-visually-hidden"),
+            legendClass = Some("visually-hidden"),
             hint = None,
             inputs = Seq(
             RadioItem(content = Text(messages("property_passing_to_direct_descendants.all")),value = Some("all")),

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/property_value.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/property_value.scala.html
@@ -52,7 +52,7 @@
 
         @inputValue(
             label = messages("property_value.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/transfer_any_unused_threshold.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/transfer_any_unused_threshold.scala.html
@@ -45,7 +45,7 @@
 
         @inputYesNo(
             label = HtmlContent(heading(messages("transfer_any_unused_threshold.title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
 

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/transfer_available_when_property_changed.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/transfer_available_when_property_changed.scala.html
@@ -46,7 +46,7 @@
 
         @inputYesNo(
             label = HtmlContent(heading(messages("transfer_available_when_property_changed.title"))),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             field = form("value")
         )
         @submitButton()

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_available_when_property_changed.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_available_when_property_changed.scala.html
@@ -47,7 +47,7 @@
 
         @inputValue(
             label = messages("chargeable_property_value.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_being_transferred.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_being_transferred.scala.html
@@ -47,7 +47,7 @@
 
         @inputValue(
             label = messages("value_being_transferred.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_of_assets_passing.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_of_assets_passing.scala.html
@@ -53,7 +53,7 @@
 
         @inputValue(
             label = messages("value_of_assets_passing.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_of_changed_property.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_of_changed_property.scala.html
@@ -48,7 +48,7 @@
 
         @inputValue(
             label = messages("value_of_changed_property.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )

--- a/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_of_estate.scala.html
+++ b/app/uk/gov/hmrc/residencenilratebandcalculator/views/value_of_estate.scala.html
@@ -58,7 +58,7 @@
 
         @inputValue(
             label = messages("value_of_estate.title"),
-            labelClass = Some("govuk-visually-hidden"),
+            labelClass = Some("visually-hidden"),
             currency = true,
             field = form("value")
         )


### PR DESCRIPTION
# DL-7124 - Re-added .visually-hidden/replaced .govuk-visually-hidden

`govuk-visually-hidden` doesn't force the width/height of the hidden text, so large hidden lables caused the page-width to increase.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
